### PR TITLE
log timestamp of rtp/rtcp packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ node dump event_log_file
 
 To dump all incoming or outgoing RTP traffic into a PCAP:
 ```
-node rtp.js event_log_file incoming | text2pcap -u 10000,20000 - some.pcap
-node rtp.js event_log_file outgoing | text2pcap -u 10000,20000 - some.pcap
+node rtp.js event_log_file incoming | text2pcap -t "%T." -u 10000,20000 - some.pcap
+node rtp.js event_log_file outgoing | text2pcap -t "%T." -u 10000,20000 - some.pcap
 ```
 
 # Generating the protobuf file


### PR DESCRIPTION
text2pcap can also export capture time of a packet, which may be very
useful when analyzing a pcap.

If the '-t' option is not provided to text2pcap it will ignore the added
timestamp and behave as before (incrementing time with one microsecond
per packet).